### PR TITLE
bitcore-node install insight-api-btx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Insight API
 
-A BitCore blockchain REST and web socket API service for [Bitcore Node BitCore](https://github.com/BTXinsight/bitcore-node-btx).
+A BitCore blockchain REST and web socket API service for [Bitcore Node BitCore](https://github.com/LIMXTEC/bitcore-node-btx).
 
-This is a backend-only service. If you're looking for the web frontend application, take a look at https://github.com/BTXinsight/insight-ui-btx.
+This is a backend-only service. If you're looking for the web frontend application, take a look at https://github.com/LIMXTEC/insight-ui-btx.
 
 ## Getting Started
 
 ```bashl
-git clone https://github.com/BTXinsight/bitcore-node-btx.git
+git clone https://github.com/LIMXTEC/bitcore-node-btx.git
 cd bitcore-node-btx
 npm install
 bitcore-node create mynode
@@ -20,7 +20,7 @@ The API endpoints will be available by default at: `http://localhost:3001/insigh
 
 ## Prerequisites
 
-- [Bitcore Node BitCore](https://github.com/BTXinsight/bitcore-node-btx)
+- [Bitcore Node BitCore](https://github.com/LIMXTEC/bitcore-node-btx)
 
 **Note:** You can use an existing BitCore data directory, however `txindex`, `addressindex`, `timestampindex` and `spentindex` needs to be set to true in `bitcore.conf`, as well as a few other additional fields.
 
@@ -76,7 +76,7 @@ To protect the server, insight-api has a built it query rate limiter. It can be 
     }
   }
 ```
-With all the configuration options available: https://github.com/BTXinsight/insight-api-btx/blob/master/lib/ratelimiter.js#L10-17
+With all the configuration options available: https://github.com/LIMXTEC/insight-api-btx/blob/master/lib/ratelimiter.js#L10-17
 
 Or disabled entirely with:
 ``` json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "insight-api-btx",
   "description": "A BitCore blockchain REST and web socket API service for Bitcore Node.",
   "version": "0.4.3",
-  "repository": "git://github.com/BTXinsight/insight-api-btx.git",
+  "repository": "git://github.com/LIMXTEC/insight-api-btx.git",
   "contributors": [
     {
       "name": "Gustavo Cortez",
@@ -46,9 +46,9 @@
     }
   ],
   "bugs": {
-    "url": "https://github.com/BTXinsight/insight-api-btx/issues"
+    "url": "https://github.com/LIMXTEC/insight-api-btx/issues"
   },
-  "homepage": "https://github.com/BTXinsight/insight-api-btx",
+  "homepage": "https://github.com/LIMXTEC/insight-api-btx",
   "license": "MIT",
   "keywords": [
     "insight",
@@ -69,8 +69,8 @@
   "bitcoreNode": "lib",
   "dependencies": {
     "async": "*",
-    "bitcore-lib-btx": "git://github.com/BTXinsight/bitcore-lib-btx#master",
-    "bitcore-message-btx": "git://github.com/BTXinsight/bitcore-message-btx#master",
+    "bitcore-lib-btx": "git://github.com/LIMXTEC/bitcore-lib-btx#master",
+    "bitcore-message-btx": "git://github.com/LIMXTEC/bitcore-message-btx#master",
     "body-parser": "^1.13.3",
     "compression": "^1.6.1",
     "lodash": "^2.4.1",


### PR DESCRIPTION
bitcore@d7fc34432dcd:~/mynode$ bitcore-node install insight-api-btx
npm ERR! Linux 4.4.0-116-generic
npm ERR! argv "/home/bitcore/.nvm/versions/node/v4.9.1/bin/node" "/home/bitcore/.nvm/versions/node/v4.9.1/bin/npm" "install" "insight-api-btx" "--save"
npm ERR! node v4.9.1
npm ERR! npm  v2.15.11
npm ERR! code E404

npm ERR! 404 Not found : insight-api-btx
npm ERR! 404 
npm ERR! 404 'insight-api-btx' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/bitcore/mynode/npm-debug.log
/home/bitcore/bitcore-node-btx/lib/cli/main.js:87
          throw err;
          ^

Error: There was an error installing service: insight-api-btx
    at ChildProcess.<anonymous> (/home/bitcore/bitcore-node-btx/lib/scaffold/add.js:56:19)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at maybeClose (internal/child_process.js:862:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:222:5)